### PR TITLE
Problemas com split e ereg

### DIFF
--- a/include/funcoes_bancoob.php
+++ b/include/funcoes_bancoob.php
@@ -181,7 +181,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_banespa.php
+++ b/include/funcoes_banespa.php
@@ -43,7 +43,7 @@ $codigocliente = formata_numero($dadosboleto["codigo_cedente"],11,0,"valor");
 $nossonumero   = substr("0000000", strlen($dadosboleto['nosso_numero'])).$dadosboleto['nosso_numero'];
 
 // Calcula vencimento juliano
-$vencjuliano = dataJuliano($vencimento);
+$vencjuliano = dataJuliano($data_venc);
 
 // Calcula Campo Livre
 $campoLivre = calculaCampoLivre($codigocliente.$nossonumero."00".$codigobanco);
@@ -204,7 +204,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_banestes.php
+++ b/include/funcoes_banestes.php
@@ -192,7 +192,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_bb.php
+++ b/include/funcoes_bb.php
@@ -212,7 +212,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_besc.php
+++ b/include/funcoes_besc.php
@@ -219,7 +219,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_bradesco.php
+++ b/include/funcoes_bradesco.php
@@ -209,7 +209,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_cef_sigcb.php
+++ b/include/funcoes_cef_sigcb.php
@@ -218,7 +218,7 @@ function direita($entra,$comp){
 
 function fator_vencimento($data) {
   if ($data != "") {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_cef_sinco.php
+++ b/include/funcoes_cef_sinco.php
@@ -210,7 +210,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_hsbc.php
+++ b/include/funcoes_hsbc.php
@@ -217,7 +217,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_itau.php
+++ b/include/funcoes_itau.php
@@ -185,7 +185,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_nossacaixa.php
+++ b/include/funcoes_nossacaixa.php
@@ -267,7 +267,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_real.php
+++ b/include/funcoes_real.php
@@ -191,7 +191,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_santander_banespa.php
+++ b/include/funcoes_santander_banespa.php
@@ -213,7 +213,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_sicredi.php
+++ b/include/funcoes_sicredi.php
@@ -240,7 +240,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];

--- a/include/funcoes_sudameris.php
+++ b/include/funcoes_sudameris.php
@@ -170,7 +170,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];
@@ -306,7 +306,7 @@ function monta_linha_digitavel($dados) {
 	// 31 a 34	Fator de vencimento
 	// 35 a 44	Valor
 
-	if (ereg('^([0-9]{5})([0-9]{4})([0-9]{5})([0-9]{5})([0-9]{5})([0-9]{5})([0-9]{1})([0-9]{4})([0-9]{10})$', $dados, $bloco))
+	if (preg_match('/^([0-9]{5})([0-9]{4})([0-9]{5})([0-9]{5})([0-9]{5})([0-9]{5})([0-9]{1})([0-9]{4})([0-9]{10})$/', $dados, $bloco))
 		{
 		$dv1 = modulo_10($bloco[1] . $bloco[2]);
 		if ($dv1 == 10) $dv1 = 0;

--- a/include/funcoes_unibanco.php
+++ b/include/funcoes_unibanco.php
@@ -192,7 +192,7 @@ function direita($entra,$comp){
 }
 
 function fator_vencimento($data) {
-	$data = split("/",$data);
+	$data = explode("/",$data);
 	$ano = $data[2];
 	$mes = $data[1];
 	$dia = $data[0];


### PR DESCRIPTION
Modificação de todos os erros relacionados as funções split (deprecated) e ereg (deprecated). Foi alterado para explode e preg_match respectivamente.
