### PR TITLE
Implementando o novo calculo do fator de data de vencimento.

### DIFF
--- a/include/funcoes_hsbc.php
+++ b/include/funcoes_hsbc.php
@@ -223,7 +223,7 @@ function fator_vencimento($data) {
 	$dia = $data[0];
 	$fator = abs((_dateToDays("1997","10","07")) - (_dateToDays($ano, $mes, $dia)));
 	if($fator > 9999){
-		$fator = ($fator%10)+1000;
+	    $fator = ($fator%9000)<1000?(($fator%9000)+9000):($fator%9000);
 	}
 	return($fator);
 }


### PR DESCRIPTION
O fator de vencimento deverá voltar para 1000 em 22/02/2025 e esse comportamento deverá ser válido para todos os proximos ciclos. 
Prazo máximo de atualização estabelecido pelo Bacen 13/04/2014.
Precisamos validar essa alteração e replicá-la para os outros arquivos de funcoes_{banco}.php
