### PR TITLE
Correção do Cálculo de Dígito Verificador Boleto Bancoob

### DIFF
--- a/boleto_bancoob.php
+++ b/boleto_bancoob.php
@@ -104,10 +104,10 @@ $calculoDv = '';
 		$calculoDv = $calculoDv + (substr($sequencia,$num,1) * $constante);
 	}
 $Resto = $calculoDv % 11;
-$Dv = 11 - $Resto;
-if ($Dv == 0) $Dv = 0;
-if ($Dv == 1) $Dv = 0;
-if ($Dv > 9) $Dv = 0;
+if($Resto == 0 || $Resto == 1)
+    $Dv = 0;
+else
+    $Dv = 11 - $Resto;
 $dadosboleto["nosso_numero"] = $NossoNumero . $Dv;
 
 /*************************************************************************


### PR DESCRIPTION
De acordo com a especificação do banco (Link na linha 49), a última especificação diz: 

"Quando o RESTO for igual a 0 ou 1 então o DV é igual a 0, pois ao subtrairmos 0 ou 1 do número 11 os resultados serão 10 ou 11, sendo que o DV do nosso número é composto por apenas um dígito".

O código anterior calcula o DV e verifica SE O DV é 0 ou 1. Pela especificação, essa verificação deve ser feita PELO RESTO e não pelo DV.

Utilizei o BoletoPHP esta semana para gerar boletos Sicoob e o banco me informou que TODOS os boletos cujo o DV deveria ser 1, o sistema estava emitindo Nosso Número inválido (com DV 0). Analisando o código, encontrei esse pequeno erro rapidamente.
