### PR TITLE
Update boleto_bancoob.php por michel

### DIFF
--- a/boleto_bancoob.php
+++ b/boleto_bancoob.php
@@ -105,8 +105,8 @@ $calculoDv = '';
 	}
 $Resto = $calculoDv % 11;
 $Dv = 11 - $Resto;
-if ($Dv == 0) $Dv = 0;
-if ($Dv == 1) $Dv = 0;
+//if ($Dv == 0) $Dv = 0;
+//if ($Dv == 1) $Dv = 0;
 if ($Dv > 9) $Dv = 0;
 $dadosboleto["nosso_numero"] = $NossoNumero . $Dv;
 


### PR DESCRIPTION
Quando o Resto for igual a 0 ou 1 então o DV é igual a 0, pois ao subtrairmos 0 ou 1 do número 11 os resultados serão 10 ou 11, sendo que o DV do nosso número é composto por apenas um dígito. do jeito que estava feito era quando o digito verificador for igual a 0 ou 1 e não o resto.

só deixando essa funciona perfeito :if ($Dv > 9) $Dv = 0;